### PR TITLE
fix: remove recursive watch for routes output directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/endpts/devtools.js#readme",
   "devDependencies": {
     "@endpts/types": "^1.1.0",
-    "@types/node": "^20.8.0",
+    "@types/node": "^20.8.2",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ devDependencies:
     specifier: ^1.1.0
     version: 1.1.0
   '@types/node':
-    specifier: ^20.8.0
-    version: 20.8.0
+    specifier: ^20.8.2
+    version: 20.8.2
   typescript:
     specifier: ^5.2.2
     version: 5.2.2
@@ -255,8 +255,8 @@ packages:
       fastq: 1.15.0
     dev: false
 
-  /@types/node@20.8.0:
-    resolution: {integrity: sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ==}
+  /@types/node@20.8.2:
+    resolution: {integrity: sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==}
     dev: true
 
   /braces@3.0.2:

--- a/src/server/builder.ts
+++ b/src/server/builder.ts
@@ -39,7 +39,7 @@ export class Builder {
   // watches the route files directory for any changes and triggers a rebuild
   async watch() {
     const routeFilePaths = await globby([
-      this.normalizePath(join(this.routesSrcDir, "**", "*.ts")),
+      join(this.routesSrcDir, "**", "*.ts"),
     ]);
 
     const ctx = await esbuild.context({
@@ -61,7 +61,7 @@ export class Builder {
     let routes: Route[] = [];
 
     const builtRouteFilePaths = await globby([
-      this.normalizePath(join(this.routesBuildOutputDir, "**", "*.js")),
+      join(this.routesBuildOutputDir, "**", "*.js"),
     ]);
 
     // once esbuild generates the new route files, we need to use them
@@ -149,11 +149,5 @@ export class Builder {
   // returns the routes build output directory
   getRoutesBuildOutputDir() {
     return this.routesBuildOutputDir;
-  }
-
-  // TODO: we can get rid of this once release 3.3.0 of fast-glob is out:
-  // https://github.com/mrmlnc/fast-glob/milestone/25
-  normalizePath(path: string) {
-    return process.platform === "win32" ? path.replace(/\\/g, "/") : path;
   }
 }

--- a/src/server/watcher.ts
+++ b/src/server/watcher.ts
@@ -39,7 +39,8 @@ export class Watcher {
   start() {
     watch(
       this.builder.getRoutesBuildOutputDir(),
-      { recursive: true },
+      // esbuild outputs route files in a flat structure, so we don't need to watch recursively
+      { recursive: false },
       this.debounce(this.reload)
     );
   }


### PR DESCRIPTION
Attempting to watch directories recursively results in `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` on some platforms such as StackBlitz.

The `recursive` option can be set to `false` since it's not necessary as esbuild outputs the bundle in a flat structure.